### PR TITLE
add continue statement to skip the rest of the code

### DIFF
--- a/continue.java
+++ b/continue.java
@@ -1,0 +1,6 @@
+for(int i=1; i<=10; i++){
+    //skip the rest of the code in the loop if the number is divisible by 3.
+    if(i%3==0){
+        continue;
+    }
+}


### PR DESCRIPTION
Unlike break statements that end a loop, continue statements skip the loop for that specific iteration.
Continue statements can be used in the same way with both for loops and while loops.